### PR TITLE
terminal-context-fd-errors

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -309,7 +309,7 @@ def register_terminal_handlers(socketio):
         # Check if session is active
         if session.active:
             # Create or get terminal session
-            terminal = TerminalManager.create_session(session_id, socketio)
+            terminal = TerminalManager.create_session(current_app._get_current_object(), session_id, socketio)
             
             # Send welcome message
             emit('terminal_output', '\r\nConnected to CoreSecFrame Terminal\r\n', room=session_id)
@@ -483,7 +483,13 @@ def register_error_handlers(app):
     
     @app.errorhandler(404)
     def not_found_error(error):
-        # Log 404 errors as they might indicate reconnaissance
+        if request.path == '/favicon.ico':
+            # Optionally, you can return a 204 No Content response for favicons
+            # or just return the standard 404 page without logging.
+            # For now, just return the 404 page without logging.
+            return render_template('errors/404.html'), 404
+
+        # Log other 404 errors as they might indicate reconnaissance
         app.logger.warning(
             f"404 Not Found: {request.path}",
             extra={

--- a/app/core/logging.py
+++ b/app/core/logging.py
@@ -37,8 +37,9 @@ class DatabaseLogHandler(logging.Handler):
             if hasattr(record, 'ip_address'):
                 log_entry.ip_address = record.ip_address
             
-            db.session.add(log_entry)
-            db.session.commit()
+            with current_app.app_context():
+                db.session.add(log_entry)
+                db.session.commit()
             
         except Exception as e:
             # Prevent logging errors from breaking the application


### PR DESCRIPTION
Fix terminal errors related to context and file descriptors.

This commit addresses several issues in the terminal manager:

1.  Resolves "Working outside of application context" errors:
    - Propagates the Flask application instance explicitly to background threads (`TerminalManager._read_output`) and methods involved in threaded operations (`_log_comprehensive_event`, `close_session`).
    - Ensures that database logging and other app-context-dependent operations within these threaded/background tasks use this explicit app instance via `with app.app_context():`.
    - Wraps direct `logger.warning/info/error` calls in `_read_output` with an app context to ensure database logging from these calls doesn't fail.
    - Fixes `DatabaseLogHandler` to use `current_app.app_context()` for its database operations.

2.  Fixes `OSError: [Errno 9] Bad file descriptor`:
    - Adds a check using `os.fstat(fd)` in the `_read_output` method before `select.select()` to ensure the file descriptor is still valid, preventing crashes if the pty has been closed.

3.  Silences `/favicon.ico` 404 logging:
    - Modifies the global 404 error handler to not log errors for `/favicon.ico` requests, reducing log noise.

The "POST request without X-Requested-With header" warning for some non-AJAX POSTs (e.g., terminal creation/closing) still exists but is considered low priority.