### PR TITLE
fix-gui-typeerror-all-pages

### DIFF
--- a/app/templates/gui/applications.html
+++ b/app/templates/gui/applications.html
@@ -104,7 +104,7 @@
                                     </div>
                                     {% endif %}
                                     <h6 class="mb-1">{{ app.display_name }}</h6>
-                                    <p class="w11-stat-tile-label">{{ app.description|truncate(80) }}</p>
+                                    <p class="w11-stat-tile-label">{{ (app.description or '')|truncate(80) }}</p>
                                     <div class="d-flex justify-content-center gap-1">
                                         <span class="badge bg-light text-dark">{{ app.category or 'Uncategorized' }}</span>
                                         {% if app.version %}

--- a/app/templates/gui/index.html
+++ b/app/templates/gui/index.html
@@ -297,7 +297,7 @@
                                             {% endif %}
                                             <div class="flex-grow-1">
                                                 <h6 class="mb-1">{{ app.display_name }}</h6>
-                                                <p class="w11-stat-tile-label">{{ app.description|truncate(60) }}</p>
+                                                <p class="w11-stat-tile-label">{{ (app.description or '')|truncate(60) }}</p>
                                                 <div class="d-flex flex-wrap gap-1">
                                                     <span class="badge bg-light text-dark">{{ app.category or 'Uncategorized' }}</span>
                                                     {% if gui_uses_wslg %}
@@ -344,7 +344,7 @@
                                             {% endif %}
                                             <div class="flex-grow-1">
                                                 <h6 class="mb-1">{{ app.display_name }}</h6>
-                                                <p class="w11-stat-tile-label">{{ app.description|truncate(60) }}</p>
+                                                <p class="w11-stat-tile-label">{{ (app.description or '')|truncate(60) }}</p>
                                                 {% if gui_uses_wslg %}
                                                 <span class="badge bg-success badge-sm">WSLg Native</span>
                                                 {% else %}


### PR DESCRIPTION
Fix: Handle None description in GUI templates (all identified pages)

Prevents a TypeError when an application's description is None. This commit addresses multiple occurrences of the same error in `app/templates/gui/index.html` and `app/templates/gui/applications.html`.

The `truncate` filter in Jinja2 would raise a TypeError if it received a None value, as it attempts to calculate the length of the input. This change provides an empty string as a default if `app.description` is None, ensuring the filter always receives a string.

The error was found in three places:
1. `gui/index.html` in the "All Applications" section.
2. `gui/index.html` in the category-specific tabs.
3. `gui/applications.html` in the main application list.